### PR TITLE
checkout, setup-node, pulumi/actions to latest

### DIFF
--- a/.github/workflows/deploy-health-checks.yml
+++ b/.github/workflows/deploy-health-checks.yml
@@ -43,7 +43,7 @@ jobs:
           pulumi-access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
       - name: Install Pulumi CLI
-        uses: pulumi/actions@v4
+        uses: pulumi/actions@v5
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/publish-accessfinland-dashboard-to-environment.yml
+++ b/.github/workflows/publish-accessfinland-dashboard-to-environment.yml
@@ -27,9 +27,9 @@ jobs:
       run:
         working-directory: accessfinland-dashboard
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "16.x"
           cache: npm
@@ -43,7 +43,7 @@ jobs:
           pulumi-access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
       - name: Install Pulumi CLI
-        uses: pulumi/actions@v4
+        uses: pulumi/actions@v5
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/publish-accessfinland-dashboard.yml
+++ b/.github/workflows/publish-accessfinland-dashboard.yml
@@ -26,9 +26,9 @@ jobs:
       run:
         working-directory: accessfinland-dashboard
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "16.x"
           cache: npm
@@ -42,7 +42,7 @@ jobs:
           pulumi-access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
       - name: Install Pulumi CLI
-        uses: pulumi/actions@v4
+        uses: pulumi/actions@v5
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/publish-cloudfront-log-forwarder-to-environment.yml
+++ b/.github/workflows/publish-cloudfront-log-forwarder-to-environment.yml
@@ -7,22 +7,21 @@ on:
         description: Environment where to deploy the stack (dev, staging)
         type: environment
         required: true
-        
+
 env:
   PULUMI_ORGANIZATION: virtualfinland
-        
+
 permissions:
   id-token: write
   contents: read
 
 jobs:
-  
   build:
     name: Build Lambda function
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x
@@ -40,7 +39,7 @@ jobs:
           name: Function_Artifact
           path: cloudfront-log-forwarder/src/bin/Release/net6.0/src.zip
           retention-days: 1
-            
+
   deploy:
     name: Deploy function to AWS ${{ inputs.environment }} environment
     runs-on: ubuntu-latest
@@ -52,18 +51,18 @@ jobs:
         working-directory: cloudfront-log-forwarder
     needs: build
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "16.x"
           cache: npm
           cache-dependency-path: cloudfront-log-forwarder/package-lock.json
-      - uses: pulumi/actions@v4
+      - uses: pulumi/actions@v5
         with:
           work-dir: ./cloudfront-log-forwarder/
-          
+
       - run: npm install
-          
+
       - uses: actions/download-artifact@v3
         with:
           name: Function_Artifact

--- a/.github/workflows/publish-cloudwatch-logs-alerts-to-environment.yml
+++ b/.github/workflows/publish-cloudwatch-logs-alerts-to-environment.yml
@@ -27,8 +27,8 @@ jobs:
       run:
         working-directory: cloudwatch-logs-alerts
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "18.x"
           cache: npm
@@ -40,7 +40,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           pulumi-access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}
       - name: Install Pulumi CLI
-        uses: pulumi/actions@v4
+        uses: pulumi/actions@v5
       - name: Install dependencies
         run: npm ci
       - name: Select Pulumi stack

--- a/.github/workflows/publish-esco-api-dashboard-to-environment.yml
+++ b/.github/workflows/publish-esco-api-dashboard-to-environment.yml
@@ -27,8 +27,8 @@ jobs:
       run:
         working-directory: esco-api-dashboard
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "16.x"
           cache: npm
@@ -40,7 +40,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           pulumi-access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}
       - name: Install Pulumi CLI
-        uses: pulumi/actions@v4
+        uses: pulumi/actions@v5
       - name: Install dependencies
         run: npm ci
       - name: Select Pulumi stack

--- a/.github/workflows/publish-esco-api-dashboard.yml
+++ b/.github/workflows/publish-esco-api-dashboard.yml
@@ -26,9 +26,9 @@ jobs:
       run:
         working-directory: esco-api-dashboard
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "16.x"
           cache: npm
@@ -42,7 +42,7 @@ jobs:
           pulumi-access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
       - name: Install Pulumi CLI
-        uses: pulumi/actions@v4
+        uses: pulumi/actions@v5
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/test-accessfinland-dashboard.yml
+++ b/.github/workflows/test-accessfinland-dashboard.yml
@@ -23,9 +23,9 @@ jobs:
       run:
         working-directory: accessfinland-dashboard
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "16.x"
           cache: npm
@@ -39,7 +39,7 @@ jobs:
           pulumi-access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
       - name: Install Pulumi CLI
-        uses: pulumi/actions@v4
+        uses: pulumi/actions@v5
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/test-esco-api-dashboard.yml
+++ b/.github/workflows/test-esco-api-dashboard.yml
@@ -23,9 +23,9 @@ jobs:
       run:
         working-directory: esco-api-dashboard
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "16.x"
           cache: npm
@@ -39,7 +39,7 @@ jobs:
           pulumi-access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
       - name: Install Pulumi CLI
-        uses: pulumi/actions@v4
+        uses: pulumi/actions@v5
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
_Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-node@v3, pulumi/actions@v4._

- checkout, setup-node @v4
- pulumi/actions@v5